### PR TITLE
Response Builders

### DIFF
--- a/src/includes/server/http/ResponseBuilder.hpp
+++ b/src/includes/server/http/ResponseBuilder.hpp
@@ -23,6 +23,8 @@ namespace NotApache {
 		static const std::string				_endLine;
 		static std::string	convertTime(time_t currentTime);
 
+		ResponseBuilder		&setDefaults();
+
 	public:
 		static const std::map<int, std::string>	statusMap;
 
@@ -32,7 +34,11 @@ namespace NotApache {
 		ResponseBuilder		&setStatus(int code);
 		ResponseBuilder		&setHeader(const std::string &key, const std::string &value);
 		ResponseBuilder		&setBody(const std::string &data, size_t length);
+		ResponseBuilder		&setBody(const std::string &data);
 		ResponseBuilder		&setDate();
+		ResponseBuilder		&setServer();
+		ResponseBuilder		&setConnection();
+		ResponseBuilder		&removeHeader(const std::string &header);
 		std::string			build();
 
 		class ResponseBuilderException : public std::exception {


### PR DESCRIPTION
Made some quality of life changes:

Now you can just use the builder like this:
```cpp
client.data.response.setResponse(
	ResponseBuilder()
	.build()
);
```
And get back a response with some defaults set:
```
HTTP/1.1 200 OK
Connection: Close
Content-Length: 0
Date: Mon, 29 March 2021 09:54:18 GMT
Server: Not-Apache
```