### PR TITLE
Makefile update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 # cmake minimum version and project name
 cmake_minimum_required(VERSION 3.16)
-project(42-webserv)
+project(42-webserv C CXX)
 
 # set compiler flags and standard
+set(CMAKE_C_STANDARD 99)
+set(FLAGS "-O3 -Wall -Wextra -Werror -pedantic-errors")
+
 set(CMAKE_CXX_STANDARD 98)
 set(FLAGS "-O3 -Wall -Wextra -Werror -pedantic-errors")
 set(CMAKE_LINK_F)
@@ -12,16 +15,20 @@ set(dir ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${dir}/build)
 
 if (APPLE)
+	set(CMAKE_C_FLAGS "${FLAGS} -DBUILD_APPLE=1")
 	set(CMAKE_CXX_FLAGS "${FLAGS} -DBUILD_APPLE=1")
 elseif(UNIX)
+	set(CMAKE_C_FLAGS "${FLAGS} -DBUILD_LINUX=1")
 	set(CMAKE_CXX_FLAGS "${FLAGS} -DBUILD_LINUX=1")
 endif ()
 
 # library files
 file(GLOB_RECURSE SOURCE_FILES
+	${CMAKE_SOURCE_DIR}/src/**.c
 	${CMAKE_SOURCE_DIR}/src/**.cpp)
 
 file(GLOB_RECURSE HEADER_FILES
+	${CMAKE_SOURCE_DIR}/src/**.h
 	${CMAKE_SOURCE_DIR}/src/**.hpp)
 
 # set the include directory

--- a/makefile
+++ b/makefile
@@ -3,20 +3,27 @@ NAME			= not-apache
 NAME			:= $(addprefix ./build/,$(NAME))
 
 # Compiler
+CC				= clang
 CXX				= clang++
 
+CC_FLAGS		= -Wall -Werror -Wextra -std=c99 -pedantic-errors
 CXX_FLAGS		= -Wall -Werror -Wextra -std=c++98 -pedantic-errors
 DEBUG_FLAGS		=
 BUILD_FLAGS		= -O3 -pthread
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
+	ifeq ($(CC),gcc)
+		CC_FLAGS += -fPIE
+	endif
 	ifeq ($(CXX),g++)
 		CXX_FLAGS += -fPIE
 	endif
+	CC_FLAGS += -DBUILD_LINUX=1
 	CXX_FLAGS += -DBUILD_LINUX=1
 else ifeq ($(UNAME_S),Darwin)
-    CXX_FLAGS += -DBUILD_APPLE=1
+	CC_FLAGS += -DBUILD_APPLE=1
+	CXX_FLAGS += -DBUILD_APPLE=1
 endif
 
 ifdef BUILD_DEBUG
@@ -199,7 +206,7 @@ HEADERS	=\
 	server/Server.hpp
 
 # Fix sources and headers
-OBJ				= $(patsubst %.cpp,%.o,$(SRC))
+OBJ				= $(patsubst %,%.o,$(SRC))
 HEADERS			:= $(addprefix $(INC_DIR)/,$(HEADERS))
 
 # Colours
@@ -222,7 +229,12 @@ $(NAME): $(addprefix $(OUT_DIR)/,$(OBJ))
 	@echo "BUILD $(NAME) $(CXX_FLAGS) $(DEBUG_FLAGS) $(BUILD_FLAGS)"
 	@$(CXX) $(CXX_FLAGS) $(DEBUG_FLAGS) $(BUILD_FLAGS) -I$(INC_DIR) -o $@ $(addprefix $(OUT_DIR)/,$(OBJ))
 
-$(OUT_DIR)/%.o: $(SRC_DIR)/%.cpp $(HEADERS)
+$(OUT_DIR)/%.c.o: $(SRC_DIR)/%.c $(HEADERS)
+	@echo "$(PREFIX)$(GREEN) Compiling file $(END)$(notdir $<) $(GREEN)to $(END)$(notdir $@)"
+	@mkdir -p $(dir $@)
+	@$(CC) $(CC_FLAGS) $(DEBUG_FLAGS) -I$(INC_DIR) -o $@ -c $<
+
+$(OUT_DIR)/%.cpp.o: $(SRC_DIR)/%.cpp $(HEADERS)
 	@echo "$(PREFIX)$(GREEN) Compiling file $(END)$(notdir $<) $(GREEN)to $(END)$(notdir $@)"
 	@mkdir -p $(dir $@)
 	@$(CXX) $(CXX_FLAGS) $(DEBUG_FLAGS) -I$(INC_DIR) -o $@ -c $<


### PR DESCRIPTION
You can now add `.c` files and `.h` directly to `SRC` and `HEADERS` in the makefile

Make sure to enclose C function prototypes like this:
```c
#ifndef TEST_H
#define TEST_H

#ifdef __cplusplus
#include <cstddef>
extern "C" {
#else
#include <stddef.h>
#endif

	void function(size_t a);

#ifdef __cplusplus
}
#endif

#endif
```